### PR TITLE
Use stable per-session IDs for payment flows to prevent cross-session…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.8.4
+### Security
+- Fixed session-isolation vulnerability: payment/session state no longer uses Python object IDs (`id(session)`) as keys in ELICITATION, PROGRESS, and DYNAMIC_TOOLS flows.
+- Replaced `id(session)` keying with stable per-session identifiers to prevent cross-session state reuse when CPython reuses object addresses.
+
 # 0.8.3
 ### Changed
 - Default x402 facilitator is now https://facilitator.paymcp.info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paymcp"
-version = "0.8.3"
+version = "0.8.4"
 description = "Provider-agnostic payment layer for MCP (Model Context Protocol) tools and agents."
 authors = [
     {name = "PayMCP Open Source Contributors", email = "dev@paymcp.info"},

--- a/src/paymcp/payment/flows/dynamic_tools.py
+++ b/src/paymcp/payment/flows/dynamic_tools.py
@@ -8,23 +8,22 @@ Monitor: https://github.com/modelcontextprotocol/python-sdk for future APIs.
 If SDK adds hooks/filters, we can remove patches and use official APIs.
 """
 import functools
-import uuid
 from typing import Dict, Any, Set, NamedTuple
 from ...utils.messages import open_link_message
 import logging
-from ...utils.context import get_ctx_from_server
+from ...utils.context import get_ctx_from_server, get_stable_session_id
 from ...utils.disconnect import is_disconnected
 
 logger = logging.getLogger(__name__)
 
 # State: payment_id -> (session_id, args)
 class PaymentSession(NamedTuple):
-    session_id: int  # Session object ID (integer for consistent lookup)
+    session_id: str  # Stable per-session identifier
     args: Dict[str, Any]
 
 PAYMENTS: Dict[str, PaymentSession] = {}  # payment_id -> PaymentSession
-HIDDEN_TOOLS: Dict[int, Set[str]] = {}  # session_id (int) -> {hidden_tool_names}
-CONFIRMATION_TOOLS: Dict[str, int] = {}  # confirm_tool_name -> session_id (int)
+HIDDEN_TOOLS: Dict[str, Set[str]] = {}  # session_id -> {hidden_tool_names}
+CONFIRMATION_TOOLS: Dict[str, str] = {}  # confirm_tool_name -> session_id
 
 
 async def _send_notification(ctx):
@@ -64,14 +63,16 @@ def make_paid_wrapper(func, mcp, providers, price_info, state_store=None, config
         )
 
         pid = str(payment_id)
-        # Extract session ID from ctx parameter (use integer ID for consistency with filter)
+        # Extract stable session ID from ctx parameter
         ctx = kwargs.get("ctx", None)
         if ctx is None and mcp is not None:
             try:
                 ctx = get_ctx_from_server(mcp)
             except Exception:
                 ctx = None
-        session_id = id(ctx.session) if ctx and hasattr(ctx, 'session') and ctx.session else uuid.uuid4().int
+        session_id = get_stable_session_id(ctx)
+        if session_id is None:
+            raise RuntimeError("No Session ID provided.")
         confirm_name = f"confirm_{tool_name}_{pid}"
 
         logger.info(f"[DYNAMIC_TOOLS] Payment initiated: tool={tool_name}, session={session_id}, payment_id={pid}")
@@ -248,7 +249,7 @@ def _patch_list_tools_immediate(mcp):
     def filtered():
         tools = orig()
         try:
-            sid = id(mcp._mcp_server.request_context.session)
+            sid = get_stable_session_id(mcp._mcp_server.request_context)
             logger.info(f"[DYNAMIC_TOOLS] Filtering tools for session {sid}, HIDDEN_TOOLS={dict(HIDDEN_TOOLS)}, CONFIRMATION_TOOLS={dict(CONFIRMATION_TOOLS)}")
         except LookupError:
             logger.info("[DYNAMIC_TOOLS] No session context (LookupError) - returning all tools")
@@ -296,12 +297,11 @@ def _patch_list_tools(mcp):
         tools = orig()
         # WHY: Use the server's public request_context to get the session ID
         # request_context is a stable property that wraps the SDK's internal ContextVar
-        # We use id(session) because session objects are reused per connection
-        # This avoids importing low-level symbols like request_ctx
+                # This avoids importing low-level symbols like request_ctx
         try:
             # Use the public Server.request_context property to fetch the current session
             # Avoids importing request_ctx from low-level internals.
-            sid = id(mcp._mcp_server.request_context.session)
+            sid = get_stable_session_id(mcp._mcp_server.request_context)
         except LookupError:
             return tools  # No session context (e.g., during testing)
         except Exception:

--- a/src/paymcp/payment/flows/elicitation.py
+++ b/src/paymcp/payment/flows/elicitation.py
@@ -4,7 +4,7 @@ import logging
 from ...utils.disconnect import is_disconnected
 from ...utils.messages import open_link_message
 from ...utils.elicitation import run_elicitation_loop
-from ...utils.context import get_ctx_from_server
+from ...utils.context import get_ctx_from_server, get_stable_session_id
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def make_paid_wrapper(func, mcp, providers, price_info, state_store=None, config
             except Exception:
                 ctx = None
         logger.debug(f"[PAYMCP Elicitation] Starting tool: {func.__name__}")
-        session_id = id(ctx.session) if ctx and hasattr(ctx, 'session') and ctx.session else None
+        session_id = get_stable_session_id(ctx)
 
         if (session_id is None):
             logger.debug(f"[PayMCP Elicitation]. Can't initiate a payment: No session_id provided")

--- a/src/paymcp/payment/flows/progress.py
+++ b/src/paymcp/payment/flows/progress.py
@@ -4,7 +4,7 @@ import functools
 from typing import Optional
 from ...utils.messages import open_link_message
 from ...utils.disconnect import is_disconnected
-from ...utils.context import get_ctx_from_server
+from ...utils.context import get_ctx_from_server, get_stable_session_id
 
 DEFAULT_POLL_SECONDS = 3          # how often to poll provider.get_payment_status
 MAX_WAIT_SECONDS = 15 * 60        # give up after 15 min 
@@ -53,7 +53,7 @@ def make_paid_wrapper(
                 except TypeError:
                     return
 
-        session_id = id(ctx.session) if ctx and hasattr(ctx, 'session') and ctx.session else None
+        session_id = get_stable_session_id(ctx)
 
         payment_id = None
         payment_url = None

--- a/src/paymcp/utils/context.py
+++ b/src/paymcp/utils/context.py
@@ -1,4 +1,5 @@
 from typing import Any
+import uuid
 
 def get_ctx_from_server(server: Any) -> Any:
     """
@@ -38,5 +39,46 @@ def capture_client_from_ctx(ctx):
     return {
         "name": getattr(client_info, "name", None) or "unknown",
         "capabilities": capabilities.model_dump() if capabilities else {},
-        "sessionId": session_id or str(id(session))
+        "sessionId": session_id or get_stable_session_id(ctx)
     }
+
+
+def get_stable_session_id(ctx: Any) -> str | None:
+    """Return a stable, non-recycled session identifier for payment/session state.
+
+    Order of preference:
+    1) Explicit client/session identifiers exposed by SDK/runtime
+    2) MCP session header value (when available)
+    3) A UUID memoized on the session object for its lifetime
+    """
+    if not ctx:
+        return None
+
+    # Prefer explicit identifiers from the SDK/runtime.
+    for value in (
+        getattr(ctx, "client_id", None),
+        getattr(getattr(ctx, "session", None), "client_id", None),
+        getattr(getattr(ctx, "session", None), "id", None),
+    ):
+        if value is not None and str(value):
+            return str(value)
+
+    request_context = getattr(ctx, "request_context", None)
+    req = getattr(request_context, "request", None) if request_context is not None else None
+    headers = getattr(req, "headers", None) if req is not None else None
+    header_sid = headers.get("mcp-session-id") if headers else None
+    if header_sid:
+        return str(header_sid)
+
+    # Fallback: persist UUID on the session object, stable for that object lifetime.
+    session = getattr(ctx, "session", None)
+    if session is None:
+        return None
+    sid = getattr(session, "_paymcp_session_uuid", None)
+    if sid is None:
+        sid = str(uuid.uuid4())
+        try:
+            setattr(session, "_paymcp_session_uuid", sid)
+        except Exception:
+            return None
+    return str(sid)


### PR DESCRIPTION
… state reuse

### Motivation
- Prevent cross-session state reuse caused by using Python object addresses (`id(session)`) which can be recycled by CPython and lead to session-isolation vulnerabilities.
- Provide a stable, portable session identifier for payment flows and related state so multi-user isolation is reliable across reconnects and runtime variations.
- Bump package version to `0.8.4` and document the security fix in the changelog.

### Description
- Added `get_stable_session_id` to `paymcp.utils.context` which prefers explicit SDK/client IDs, then an `mcp-session-id` header, and finally memoizes a UUID on the session object as a fallback.
- Replaced usages of `id(session)` with `get_stable_session_id` across payment flows: `dynamic_tools.py`, `elicitation.py`, and `progress.py`.
- Converted in-memory maps to use string session IDs and updated related types: `PAYMENTS`, `HIDDEN_TOOLS`, and `CONFIRMATION_TOOLS` now key by stable `str` IDs and `PaymentSession.session_id` is a `str`.
- Updated `capture_client_from_ctx` to use the new stable session ID and added defensive checks and a runtime error when no session ID can be determined during dynamic tool initiation.
- Bumped project version to `0.8.4` and added a changelog entry summarizing the security fix.

### Testing
- Ran the unit test suite with `pytest`, and all tests completed successfully (no regressions observed).
- Exercised payment flows that rely on session state in CI/local tests to verify that tools are hidden/shown per-session and confirmation tools are scoped to the initiating session.